### PR TITLE
rebuilding dockerfile by updating a comment

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -2,3 +2,5 @@ FROM gitpod/workspace-full
 
 RUN brew install clojure/tools/clojure
 RUN brew install leiningen
+
+# rebuilding dockerfile by updating this comment #1


### PR DESCRIPTION
.gitpod.dockerfile will only get rebuilt when it gets updated.
This PR adds a comment to `.gitpod.dockerfile`, which trigger an image rebuild.

Hope https://github.com/gitpod-io/gitpod/issues/4126 will be implemented soon. 